### PR TITLE
feat: save the current existing PR description

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -19723,12 +19723,20 @@ ${template}
       ],
       max_tokens: 4096
     });
-    const prDescription = response.choices[0].message.content.trim();
+    const { data: pr2 } = await octokit.rest.pulls.get({
+      owner: owner2,
+      repo: repo2,
+      pull_number: pullNumber2
+    });
+    const existingDescription = pr2.body ? pr2.body.trim() : "";
+    const newPrDescription = response.choices[0].message.content.trim();
+    const separator = "\n\n---\n\n";
+    const finalDescription = existingDescription ? `${existingDescription}${separator}${newPrDescription}` : newPrDescription;
     await octokit.rest.pulls.update({
       owner: owner2,
       repo: repo2,
       pull_number: pullNumber2,
-      body: prDescription
+      body: finalDescription
     });
     console.log("PR description updated successfully!");
   } catch (error) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -19648,39 +19648,40 @@ if (!openaiApiKey || !githubToken) {
 var openai = new openai_default({ apiKey: openaiApiKey });
 var octokit = new Octokit2({ auth: githubToken });
 console.log(
-  `Generating PR description for ${owner}/${repo}#${pullNumber}/${branchName}`
+  `Generating PR description for ${owner}/${repo}#${pullNumber} (${branchName})`
 );
 async function generatePRDescription(owner2, repo2, pullNumber2, branchName2) {
   try {
     const jiraTicketMatch = branchName2.match(/(CDB|DBP)-\d+/);
     const jiraTicket = jiraTicketMatch ? jiraTicketMatch[0] : "CDB-0000";
     const jiraURL = `https://botrista-sw.atlassian.net/browse/${jiraTicket}`;
-    const { data: commits } = await octokit.rest.pulls.listCommits({
-      owner: owner2,
-      repo: repo2,
-      pull_number: pullNumber2
-    });
-    const { data: files } = await octokit.rest.pulls.listFiles({
-      owner: owner2,
-      repo: repo2,
-      pull_number: pullNumber2
-    });
-    const { data: diff } = await octokit.request(
-      `GET /repos/{owner}/{repo}/pulls/{pull_number}`,
-      {
+    const [{ data: commits }, { data: files }, { data: pr2 }] = await Promise.all([
+      octokit.rest.pulls.listCommits({
         owner: owner2,
         repo: repo2,
-        pull_number: pullNumber2,
-        headers: {
-          accept: "application/vnd.github.v3.diff"
+        pull_number: pullNumber2
+      }),
+      octokit.rest.pulls.listFiles({ owner: owner2, repo: repo2, pull_number: pullNumber2 }),
+      octokit.rest.pulls.get({ owner: owner2, repo: repo2, pull_number: pullNumber2 })
+    ]);
+    const commitMessages = commits.map((c2) => `- ${c2.commit.message}`).join("\n");
+    const fileChanges = files.map((f2) => `- ${f2.filename} (${f2.status})`).join("\n");
+    let diff = "";
+    try {
+      const { data: rawDiff } = await octokit.request(
+        `GET /repos/{owner}/{repo}/pulls/{pull_number}`,
+        {
+          owner: owner2,
+          repo: repo2,
+          pull_number: pullNumber2,
+          headers: { accept: "application/vnd.github.v3.diff" }
         }
-      }
-    );
-    const commitMessages = commits.map((commit) => `- ${commit.commit.message}`).join("\n");
-    const fileChanges = files.map((file) => `- ${file.filename} (${file.status})`).join("\n");
-    console.log("Commit messages:", commitMessages);
-    console.log("File changes:", fileChanges);
-    console.log("Code diff:", diff);
+      );
+      diff = rawDiff.length > 2e4 ? rawDiff.slice(0, 2e4) + "\n\n[Diff truncated]" : rawDiff;
+    } catch (err) {
+      console.warn("Warning: Unable to fetch diff, proceeding without it.");
+    }
+    const existingDescription = pr2.body ? pr2.body.trim() : "";
     const template = `
 ## Description
 <!-- Replace this line to describe what this PR does -->
@@ -19697,16 +19698,19 @@ async function generatePRDescription(owner2, repo2, pullNumber2, branchName2) {
     const prompt = `
 Generate a GitHub pull request description based on the following details:
 
+Existing PR description:
+${existingDescription || "(No existing description)"}
+
 Commit messages:
 ${commitMessages}
 
 File changes:
 ${fileChanges}
 
-Code diff:
+Code diff (truncated if too long):
 ${diff}
 
-Format the description with the following template:
+Format the description using this template:
 ${template}
     `;
     const response = await openai.chat.completions.create({
@@ -19716,20 +19720,15 @@ ${template}
           role: "system",
           content: "You are a helpful assistant for generating PR descriptions."
         },
-        {
-          role: "user",
-          content: prompt
-        }
+        { role: "user", content: prompt }
       ],
       max_tokens: 4096
     });
-    const { data: pr2 } = await octokit.rest.pulls.get({
-      owner: owner2,
-      repo: repo2,
-      pull_number: pullNumber2
-    });
-    const existingDescription = pr2.body ? pr2.body.trim() : "";
-    const newPrDescription = response.choices[0].message.content.trim();
+    const newPrDescription = response.choices[0]?.message?.content?.trim() || "";
+    if (!newPrDescription) {
+      console.error("Error: OpenAI returned an empty response.");
+      process.exit(1);
+    }
     const separator = "\n\n---\n\n";
     const finalDescription = existingDescription ? `${existingDescription}${separator}${newPrDescription}` : newPrDescription;
     await octokit.rest.pulls.update({
@@ -19741,7 +19740,6 @@ ${template}
     console.log("PR description updated successfully!");
   } catch (error) {
     console.error("Error generating PR description:", error.message);
-    console.error("Error:", error);
     process.exit(1);
   }
 }

--- a/index.mjs
+++ b/index.mjs
@@ -120,14 +120,29 @@ ${template}
       max_tokens: 4096
     })
 
-    const prDescription = response.choices[0].message.content.trim()
+    // Get PR details (including current description)
+    const { data: pr } = await octokit.rest.pulls.get({
+      owner,
+      repo,
+      pull_number: pullNumber
+    })
+
+    const existingDescription = pr.body ? pr.body.trim() : ''
+
+    const newPrDescription = response.choices[0].message.content.trim()
+
+    // If PR already has content, append the new content with a separator
+    const separator = '\n\n---\n\n'
+    const finalDescription = existingDescription
+      ? `${existingDescription}${separator}${newPrDescription}`
+      : newPrDescription
 
     // Update PR description
     await octokit.rest.pulls.update({
       owner,
       repo,
       pull_number: pullNumber,
-      body: prDescription
+      body: finalDescription
     })
 
     console.log('PR description updated successfully!')

--- a/index.mjs
+++ b/index.mjs
@@ -24,56 +24,60 @@ const openai = new OpenAI({ apiKey: openaiApiKey })
 const octokit = new Octokit({ auth: githubToken })
 
 console.log(
-  `Generating PR description for ${owner}/${repo}#${pullNumber}/${branchName}`
+  `Generating PR description for ${owner}/${repo}#${pullNumber} (${branchName})`
 )
 
 async function generatePRDescription(owner, repo, pullNumber, branchName) {
   try {
-    // Get Jira Ticket (Support CDB-xxxx and DBP-xxxx)
+    // Extract Jira Ticket from branch name
     const jiraTicketMatch = branchName.match(/(CDB|DBP)-\d+/)
     const jiraTicket = jiraTicketMatch ? jiraTicketMatch[0] : 'CDB-0000'
-
-    // Create Jira URL
     const jiraURL = `https://botrista-sw.atlassian.net/browse/${jiraTicket}`
 
-    // Get PR commits and changes
-    const { data: commits } = await octokit.rest.pulls.listCommits({
-      owner,
-      repo,
-      pull_number: pullNumber
-    })
-    const { data: files } = await octokit.rest.pulls.listFiles({
-      owner,
-      repo,
-      pull_number: pullNumber
-    })
-
-    // Get PR's code diff
-    const { data: diff } = await octokit.request(
-      `GET /repos/{owner}/{repo}/pulls/{pull_number}`,
-      {
-        owner,
-        repo,
-        pull_number: pullNumber,
-        headers: {
-          accept: 'application/vnd.github.v3.diff'
-        }
-      }
-    )
+    // Fetch PR commits and changed files
+    const [{ data: commits }, { data: files }, { data: pr }] =
+      await Promise.all([
+        octokit.rest.pulls.listCommits({
+          owner,
+          repo,
+          pull_number: pullNumber
+        }),
+        octokit.rest.pulls.listFiles({ owner, repo, pull_number: pullNumber }),
+        octokit.rest.pulls.get({ owner, repo, pull_number: pullNumber })
+      ])
 
     // Extract commit messages and file changes
     const commitMessages = commits
-      .map((commit) => `- ${commit.commit.message}`)
+      .map((c) => `- ${c.commit.message}`)
       .join('\n')
     const fileChanges = files
-      .map((file) => `- ${file.filename} (${file.status})`)
+      .map((f) => `- ${f.filename} (${f.status})`)
       .join('\n')
 
-    console.log('Commit messages:', commitMessages)
-    console.log('File changes:', fileChanges)
-    console.log('Code diff:', diff)
+    // Fetch PR diff (with a size limit)
+    let diff = ''
+    try {
+      const { data: rawDiff } = await octokit.request(
+        `GET /repos/{owner}/{repo}/pulls/{pull_number}`,
+        {
+          owner,
+          repo,
+          pull_number: pullNumber,
+          headers: { accept: 'application/vnd.github.v3.diff' }
+        }
+      )
+      diff =
+        rawDiff.length > 20000
+          ? rawDiff.slice(0, 20000) + '\n\n[Diff truncated]'
+          : rawDiff
+    } catch (err) {
+      console.warn('Warning: Unable to fetch diff, proceeding without it.')
+    }
 
-    // Prepare prompt for OpenAI
+    // Get existing PR description
+    const existingDescription = pr.body ? pr.body.trim() : ''
+
+    // Define PR template
     const template = `
 ## Description
 <!-- Replace this line to describe what this PR does -->
@@ -88,8 +92,12 @@ async function generatePRDescription(owner, repo, pullNumber, branchName) {
 [${jiraTicket}](${jiraURL})
     `
 
+    // Prepare OpenAI prompt
     const prompt = `
 Generate a GitHub pull request description based on the following details:
+
+Existing PR description:
+${existingDescription || '(No existing description)'}
 
 Commit messages:
 ${commitMessages}
@@ -97,10 +105,10 @@ ${commitMessages}
 File changes:
 ${fileChanges}
 
-Code diff:
+Code diff (truncated if too long):
 ${diff}
 
-Format the description with the following template:
+Format the description using this template:
 ${template}
     `
 
@@ -112,32 +120,25 @@ ${template}
           role: 'system',
           content: 'You are a helpful assistant for generating PR descriptions.'
         },
-        {
-          role: 'user',
-          content: prompt
-        }
+        { role: 'user', content: prompt }
       ],
       max_tokens: 4096
     })
 
-    // Get PR details (including current description)
-    const { data: pr } = await octokit.rest.pulls.get({
-      owner,
-      repo,
-      pull_number: pullNumber
-    })
+    const newPrDescription = response.choices[0]?.message?.content?.trim() || ''
 
-    const existingDescription = pr.body ? pr.body.trim() : ''
+    if (!newPrDescription) {
+      console.error('Error: OpenAI returned an empty response.')
+      process.exit(1)
+    }
 
-    const newPrDescription = response.choices[0].message.content.trim()
-
-    // If PR already has content, append the new content with a separator
+    // Append new content to existing PR description
     const separator = '\n\n---\n\n'
     const finalDescription = existingDescription
       ? `${existingDescription}${separator}${newPrDescription}`
       : newPrDescription
 
-    // Update PR description
+    // Update PR description on GitHub
     await octokit.rest.pulls.update({
       owner,
       repo,
@@ -148,7 +149,6 @@ ${template}
     console.log('PR description updated successfully!')
   } catch (error) {
     console.error('Error generating PR description:', error.message)
-    console.error('Error:', error)
     process.exit(1)
   }
 }


### PR DESCRIPTION
## Description
- Added a feature to preserve the existing PR description if it already exists.
- If a PR has a description, the new AI-generated content will be appended below it, separated by ---.
- This ensures that manually written content remains intact while supplementing it with AI-generated insights.
## Changes
- Modified the generatePRDescription function first to retrieve the current PR description.
- If an existing description is found, the new content is appended instead of replacing it.
- Use the existing description in the prompt to generate the better one.
- Use the `Promise.all` to optimize the API response.
- Truncate the code diff to prevent it from being too long.
- A separator (---) is added between the original and the newly generated description to maintain clarity.